### PR TITLE
Update migration scripts for rails 5.2, add missing TestTask

### DIFF
--- a/db/migrate/001_create_release_notes.rb
+++ b/db/migrate/001_create_release_notes.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along with
 # redmine_release_notes. If not, see <http://www.gnu.org/licenses/>.
 
-class CreateReleaseNotes < ActiveRecord::Migration
+class CreateReleaseNotes < ActiveRecord::Migration[5.2]
   def up
     create_table :release_notes do |t|
       t.column :issue_id, :integer

--- a/db/migrate/002_increase_release_notes_length_limit.rb
+++ b/db/migrate/002_increase_release_notes_length_limit.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along with
 # redmine_release_notes. If not, see <http://www.gnu.org/licenses/>.
 
-class IncreaseReleaseNotesLengthLimit < ActiveRecord::Migration
+class IncreaseReleaseNotesLengthLimit < ActiveRecord::Migration[5.2]
   def up
     change_column :release_notes, :text, :string, :limit => 2000
   end

--- a/db/migrate/003_do_everything_for_version_130.rb
+++ b/db/migrate/003_do_everything_for_version_130.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along with
 # redmine_release_notes. If not, see <http://www.gnu.org/licenses/>.
 
-class DoEverythingForVersion130 < ActiveRecord::Migration
+class DoEverythingForVersion130 < ActiveRecord::Migration[5.2]
   def up
     change_table :release_notes do |t|
       t.column :status,   :string,  :limit => 12

--- a/db/migrate/004_do_everything_for_version_131.rb
+++ b/db/migrate/004_do_everything_for_version_131.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along with
 # redmine_release_notes. If not, see <http://www.gnu.org/licenses/>.
 
-class DoEverythingForVersion131 < ActiveRecord::Migration
+class DoEverythingForVersion131 < ActiveRecord::Migration[5.2]
   def up
     # remove release_notes.status => now a custom field
     remove_column :release_notes, :status

--- a/db/migrate/005_do_everything_for_version_132.rb
+++ b/db/migrate/005_do_everything_for_version_132.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along with
 # redmine_release_notes. If not, see <http://www.gnu.org/licenses/>.
 
-class DoEverythingForVersion132 < ActiveRecord::Migration
+class DoEverythingForVersion132 < ActiveRecord::Migration[5.2]
   def up
     change_column :release_notes_formats, :header, :text, limit: 16.megabytes - 1
     change_column :release_notes_formats, :each_issue, :text, limit: 16.megabytes - 1

--- a/lib/tasks/redmine.rake
+++ b/lib/tasks/redmine.rake
@@ -15,6 +15,7 @@
 # redmine_release_notes. If not, see <http://www.gnu.org/licenses/>.
 
 require 'yaml'
+require "rake/testtask.rb"
 
 namespace :redmine do
   namespace :plugins do


### PR DESCRIPTION
You're probably not interested in this pull-request, but I'm putting it here in case it's useful for anyone.